### PR TITLE
Reduce size of handel-codepipeline spec file

### DIFF
--- a/lib/codebuild/index.js
+++ b/lib/codebuild/index.js
@@ -106,13 +106,13 @@ function createDeployPhaseCodeBuildProject(accountId, projectName, deployPhase, 
     return createDeployPhaseServiceRole(accountId)
         .then(deployPhaseRole => {
             let handelDeployEnvVars = {
-                ENVS_TO_DEPLOY: deployPhase.envs.join(","),
+                ENVS_TO_DEPLOY: deployPhase.environments_to_deploy.join(","),
                 HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString("base64")
             }
             let handelDeployImage = "aws/codebuild/nodejs:6.3.1";
             let handelDeployBuildSpec = util.loadFile(`${__dirname}/deploy-buildspec.yml`);
 
-            let deployProjectName = codeBuildCalls.getDeployProjectName(projectName, deployPhase.envs);
+            let deployProjectName = codeBuildCalls.getDeployProjectName(projectName, deployPhase.environments_to_deploy);
             return codeBuildCalls.createProject(deployProjectName, projectName, handelDeployImage, handelDeployEnvVars, accountId, deployPhaseRole.Arn, handelDeployBuildSpec);
         });
 }
@@ -123,7 +123,7 @@ function createCodeBuildProjectsInAccount(accountId, projectName, pipelineDefini
     //Create deploy phase projects
     for(let i = 2; i < pipelineDefinition.phases.length; i++) {
         let phase = pipelineDefinition.phases[i];
-        if(phase.phase_type === 'deploy') {
+        if(phase.type === 'handel') {
             createPromises.push(createDeployPhaseCodeBuildProject(accountId, projectName, phase, accountConfig));
         }
     }

--- a/lib/codepipeline/index.js
+++ b/lib/codepipeline/index.js
@@ -78,21 +78,23 @@ function createCodePipelineRole(accountId) {
 
 function validatePipelineDefinition(pipelineDefinition) {
     let phases = pipelineDefinition.phases;
-    if (phases[0].phase_type !== 'source') {
-        throw new Error("The first phase of your pipeline must be a source phase");
+    if (phases[0].type !== 'github') {
+        throw new Error("The first phase of your pipeline must be a github phase");
     }
-    if (phases[1].phase_type !== 'build') {
-        throw new Error("The second phase of your pipeline must be a build phase");
+    if (phases[1].type !== 'codebuild') {
+        throw new Error("The second phase of your pipeline must be a codebuild phase");
     }
 }
 
 function getSourcePhase(phaseSpec, githubAccessToken) {
+    let branch = phaseSpec.branch || "master";
+
     return {
-        name: phaseSpec.phase_name,
+        name: phaseSpec.name,
         actions: [
             {
                 inputArtifacts: [],
-                name: phaseSpec.phase_name,
+                name: phaseSpec.name,
                 actionTypeId: {
                     category: "Source",
                     owner: "ThirdParty",
@@ -101,13 +103,13 @@ function getSourcePhase(phaseSpec, githubAccessToken) {
                 },
                 outputArtifacts: [
                     {
-                        name: `Output_${phaseSpec.phase_name}`
+                        name: `Output_${phaseSpec.name}`
                     }
                 ],
                 configuration: {
                     Owner: phaseSpec.owner,
                     Repo: phaseSpec.repo,
-                    Branch: phaseSpec.branch,
+                    Branch: branch,
                     OAuthToken: githubAccessToken
                 },
                 runOrder: 1
@@ -122,15 +124,15 @@ function getBuildPhase(sourcePhaseSpec, phaseSpec, handelFile) {
     }
 
     return {
-        name: phaseSpec.phase_name,
+        name: phaseSpec.name,
         actions: [
             {
                 inputArtifacts: [
                     {
-                        name: `Output_${sourcePhaseSpec.phase_name}`
+                        name: `Output_${sourcePhaseSpec.name}`
                     }
                 ],
-                name: phaseSpec.phase_name,
+                name: phaseSpec.name,
                 actionTypeId: {
                     category: "Build",
                     owner: "AWS",
@@ -139,7 +141,7 @@ function getBuildPhase(sourcePhaseSpec, phaseSpec, handelFile) {
                 },
                 outputArtifacts: [
                     {
-                        name: `Output_${phaseSpec.phase_name}`
+                        name: `Output_${phaseSpec.name}`
                     }
                 ],
                 configuration: {
@@ -158,15 +160,15 @@ function getDeployPhase(buildPhaseSpec, phaseSpec, handelFile) {
 
     //TODO - Validate the envs are in the handel file
     return {
-        name: phaseSpec.phase_name,
+        name: phaseSpec.name,
         actions: [
             {
                 inputArtifacts: [
                     {
-                        name: `Output_${buildPhaseSpec.phase_name}`
+                        name: `Output_${buildPhaseSpec.name}`
                     }
                 ],
-                name: phaseSpec.phase_name,
+                name: phaseSpec.name,
                 actionTypeId: {
                     category: "Test",
                     owner: "AWS",
@@ -174,7 +176,7 @@ function getDeployPhase(buildPhaseSpec, phaseSpec, handelFile) {
                     provider: "CodeBuild"
                 },
                 configuration: {
-                    ProjectName: codeBuildCalls.getDeployProjectName(handelFile.name, phaseSpec.envs)
+                    ProjectName: codeBuildCalls.getDeployProjectName(handelFile.name, phaseSpec.environments_to_deploy)
                 },
                 runOrder: 1
             }
@@ -183,13 +185,13 @@ function getDeployPhase(buildPhaseSpec, phaseSpec, handelFile) {
 }
 
 function getPhase(sourcePhaseSpec, buildPhaseSpec, phaseSpec, handelFile, githubAccessToken) {
-    let phaseType = phaseSpec.phase_type;
+    let phaseType = phaseSpec.type;
     switch (phaseType) {
-        case "source":
+        case "github":
             return getSourcePhase(phaseSpec, githubAccessToken);
-        case "build":
+        case "codebuild":
             return getBuildPhase(sourcePhaseSpec, phaseSpec, handelFile);
-        case "deploy":
+        case "handel":
             return getDeployPhase(buildPhaseSpec, phaseSpec, handelFile);
         default:
             throw new Error(`Unsupported phase type specified: ${phaseType}`);
@@ -199,7 +201,6 @@ function getPhase(sourcePhaseSpec, buildPhaseSpec, phaseSpec, handelFile, github
 function createCodePipelineProject(codePipeline, accountId, projectName, codePipelineBucketName, pipelineDefinition, handelFile, githubAccessToken) {
     return createCodePipelineRole(accountId)
         .then(codePipelineRole => {
-            console.log(codePipelineRole);
             let createParams = {
                 pipeline: {
                     version: 1,
@@ -216,14 +217,14 @@ function createCodePipelineProject(codePipeline, accountId, projectName, codePip
             let phasesSpec = pipelineDefinition.phases;
             //Add source phase (required)
             let sourcePhaseSpec = phasesSpec[0];
-            if (!sourcePhaseSpec || sourcePhaseSpec.phase_type !== 'source') {
-                throw new Error("Source phase is required and must be the first phase of the pipeline");
+            if (!sourcePhaseSpec || sourcePhaseSpec.type !== 'github') {
+                throw new Error("github phase is required and must be the first phase of the pipeline");
             }
             createParams.pipeline.stages.push(getPhase(null, null, sourcePhaseSpec, handelFile, githubAccessToken));
             //Add build phase (required)
             let buildPhaseSpec = phasesSpec[1];
-            if (!buildPhaseSpec || buildPhaseSpec.phase_type !== 'build') {
-                throw new Error("Build phase is required and must be the second phase of the pipeline");
+            if (!buildPhaseSpec || buildPhaseSpec.type !== 'codebuild') {
+                throw new Error("codebuild phase is required and must be the second phase of the pipeline");
             }
             createParams.pipeline.stages.push(getPhase(sourcePhaseSpec, null, buildPhaseSpec, handelFile));
 

--- a/lib/input/index.js
+++ b/lib/input/index.js
@@ -53,7 +53,7 @@ exports.getAccountIdsFromPipelineNames = function(pipelineNames) {
         questions.push({
             type: 'input',
             name: pipelineName,
-            message: `What is the ID of the account you wish to use for your pipeline ${pipelineName}`, 
+            message: `What is the ID of the account you wish to use for your pipeline '${pipelineName}'`, 
         })
     }
     return inquirer.prompt(questions);

--- a/test/lib/codebuild/handel-codepipeline-example.yml
+++ b/test/lib/codebuild/handel-codepipeline-example.yml
@@ -3,19 +3,17 @@ version: 1
 pipelines:
   dev:
     phases:
-    - phase_type: source
-      action_type: github
-      phase_name: Source
+    - type: github
+      name: Source
       owner: dsw88
       repo: FakeRepo
       branch: master
-    - phase_type: build
-      action_type: codebuild
-      phase_name: Build
+    - type: codebuild
+      name: Build
       build_image: aws/codebuild/python:3.5.2
       environment_variables:
         ENV_NAME: env_value
-    - phase_type: deploy
-      phase_name: Deploy
-      envs:
+    - type: handel
+      name: DevDeploy
+      environments_to_deploy:
       - dev

--- a/test/lib/codepipeline/handel-codepipeline-example.yml
+++ b/test/lib/codepipeline/handel-codepipeline-example.yml
@@ -3,20 +3,17 @@ version: 1
 pipelines:
   dev:
     phases:
-    - phase_type: source
-      action_type: github
-      phase_name: Source
+    - type: github
+      name: Source
       owner: dsw88
       repo: FakeRepo
       branch: master
-    - phase_type: build
-      action_type: codebuild
-      phase_name: Build
+    - type: codebuild
+      name: Build
       build_image: aws/codebuild/python:3.5.2
       environment_variables:
         ENV_NAME: env_value
-    - phase_type: deploy
-      action_type: handel
-      phase_name: Deploy
-      envs:
+    - type: handel
+      name: DevDeploy
+      environments_to_deploy:
       - dev


### PR DESCRIPTION
This change removes some of the unnecessary complexity of the spec
file. In particular, it now only requires one 'type' parameter
and just infers what phase type in codepipeline