### PR TITLE
Allow CodeBuild to access EC2 Parameter Store for app's params

### DIFF
--- a/lib/aws/codebuild-calls.js
+++ b/lib/aws/codebuild-calls.js
@@ -1,10 +1,39 @@
 const AWS = require('aws-sdk');
+const winston = require('winston');
 
 function getCodeBuildEnvVarDef(key, value) {
     return {
         name: key,
         value: value
     }
+}
+
+function createProject(codeBuild, createParams) {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+    });
+
+    function createProject() {
+        codeBuild.createProject(createParams).promise()
+            .then(projectResponse => {
+                deferred.resolve(projectResponse);
+            })
+            .catch(err => {
+                if(err.code === 'InvalidInputException') { //Try again because the IAM role isn't available yet
+                    setTimeout(function() {
+                        createProject();
+                    }, 5000);  
+                }
+                else {
+                    deferred.reject(err);
+                }
+            });
+    }
+    createProject();
+
+    return deferred.promise;
 }
 
 exports.getBuildProjectName = function(handelFileName) {
@@ -56,7 +85,7 @@ exports.createProject = function (projectName, handelFileName, imageName, enviro
         createParams.environment.environmentVariables.push(getCodeBuildEnvVarDef(envKey, environmentVariables[envKey]));
     }
 
-    return codeBuild.createProject(createParams).promise()
+    return createProject(codeBuild, createParams)
         .then(createResponse => {
             return createResponse.project;
         });

--- a/lib/aws/codepipeline-calls.js
+++ b/lib/aws/codepipeline-calls.js
@@ -76,6 +76,34 @@ function createCodePipelineRole(accountId) {
         });
 }
 
+function createPipeline(codePipeline, createParams) {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+    });
+
+    function createPipeline() {
+        codePipeline.createPipeline(createParams).promise()
+            .then(createResult => {
+                deferred.resolve(createResult);
+            })
+            .catch(err => {
+                if(err.code === 'InvalidStructureException') { //Try again because the IAM role isn't available yet
+                    setTimeout(function() {
+                        createPipeline();
+                    }, 5000);  
+                }
+                else {
+                    deferred.reject(err);
+                }
+            });
+    }
+    createPipeline();
+
+    return deferred.promise;
+}
+
 
 function createCodePipelineProject(codePipeline, accountId, projectName, codePipelineBucketName, codePipelinePhases) {
     return createCodePipelineRole(accountId)
@@ -97,7 +125,7 @@ function createCodePipelineProject(codePipeline, accountId, projectName, codePip
                 createParams.pipeline.stages.push(phase);
             }
 
-            return codePipeline.createPipeline(createParams).promise()
+            return createPipeline(codePipeline, createParams)
                 .then(createResult => {
                     return createResult.pipeline;
                 });

--- a/lib/lifecycle/index.js
+++ b/lib/lifecycle/index.js
@@ -58,8 +58,6 @@ exports.validatePipelineSpec = function(handelFile, handelCodePipelineFile) {
         }
     }
 
-    console.log(errors);
-
     return errors;
 }
 

--- a/lib/phases/codebuild/build-phase-service-policy.json
+++ b/lib/phases/codebuild/build-phase-service-policy.json
@@ -1,0 +1,64 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+                "codebuild:BatchGet*",
+                "codebuild:Get*",
+                "codebuild:List*",
+                "codecommit:GetBranch",
+                "codecommit:GetCommit",
+                "codecommit:GetRepository",
+                "codecommit:ListBranches",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeImages",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:InitiateLayerUpload",
+                "ecr:ListImages",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart",
+                "events:PutRule",
+                "events:RemoveTargets",
+                "iam:CreateRole",
+                "iam:GetRole",
+                "iam:GetInstanceProfile",
+                "iam:PassRole",
+                "iam:ListInstanceProfiles",
+                "logs:*",
+                "s3:CreateBucket",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:List*",
+                "s3:PutObject"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "logs:GetLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:log-group:/aws/codebuild/*:log-stream:*",
+            "Effect": "Allow"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:DescribeParameters"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:{{region}}:{{accountId}}:parameter/{{appName}}*"
+        }
+    ]
+}

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -2,63 +2,22 @@ const iamCalls = require('../../aws/iam-calls');
 const codeBuildCalls = require('../../aws/codebuild-calls');
 const winston = require('winston');
 const inquirer = require('inquirer');
+const util = require('../../util/util');
 
-function createBuildPhaseServiceRole(accountId) {
-    let roleName = 'HandelCodePipelineBuildPhaseServiceRole';
+function createBuildPhaseServiceRole(accountConfig, handelAppName) {
+    let roleName = `${handelAppName}-HandelCodePipelineBuildPhase`;
     return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
         .then(role => {
-            let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
-            let policyDocument = {
-                Version: "2012-10-17",
-                Statement: [
-                    {
-                        Action: [
-                            "codebuild:StartBuild",
-                            "codebuild:StopBuild",
-                            "codebuild:BatchGet*",
-                            "codebuild:Get*",
-                            "codebuild:List*",
-                            "codecommit:GetBranch",
-                            "codecommit:GetCommit",
-                            "codecommit:GetRepository",
-                            "codecommit:ListBranches",
-                            "ecr:BatchCheckLayerAvailability",
-                            "ecr:BatchGetImage",
-                            "ecr:CompleteLayerUpload",
-                            "ecr:DescribeImages",
-                            "ecr:GetAuthorizationToken",
-                            "ecr:GetDownloadUrlForLayer",
-                            "ecr:InitiateLayerUpload",
-                            "ecr:ListImages",
-                            "ecr:PutImage",
-                            "ecr:UploadLayerPart",
-                            "events:PutRule",
-                            "events:RemoveTargets",
-                            "iam:CreateRole",
-                            "iam:GetRole",
-                            "iam:GetInstanceProfile",
-                            "iam:PassRole",
-                            "iam:ListInstanceProfiles",
-                            "logs:*",
-                            "s3:CreateBucket",
-                            "s3:GetBucketLocation",
-                            "s3:GetObject",
-                            "s3:List*",
-                            "s3:PutObject"
-                        ],
-                        Resource: "*",
-                        Effect: "Allow"
-                    },
-                    {
-                        Action: [
-                            "logs:GetLogEvents"
-                        ],
-                        Resource: "arn:aws:logs:*:*:log-group:/aws/codebuild/*:log-stream:*",
-                        Effect: "Allow"
-                    }
-                ]
+            let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/handel-codepipeline/${roleName}`;
+            let policyDocParams = {
+                region: accountConfig.region,
+                accountId: accountConfig.account_id,
+                appName: handelAppName
             }
-            return iamCalls.createPolicyIfNotExists(roleName, policyArn, policyDocument);
+            return util.compileHandlebarsTemplate(`${__dirname}/build-phase-service-policy.json`, policyDocParams)
+                .then(compiledPolicyDoc => {
+                    return iamCalls.createPolicyIfNotExists(roleName, policyArn, JSON.parse(compiledPolicyDoc));
+                });
         })
         .then(policy => {
             return iamCalls.attachPolicyToRole(policy.Arn, roleName);
@@ -74,7 +33,7 @@ function createBuildPhaseCodeBuildProject(phaseContext) {
 
     let buildProjectName = codeBuildCalls.getBuildProjectName(handelAppName);
 
-    return createBuildPhaseServiceRole(phaseContext.accountConfig.account_id)
+    return createBuildPhaseServiceRole(phaseContext.accountConfig, handelAppName)
         .then(buildPhaseRole => {
             return codeBuildCalls.createProject(buildProjectName, handelAppName, phaseContext.params.build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
         });
@@ -112,7 +71,7 @@ function getCodePipelinePhaseSpec(phaseContext) {
     }
 }
 
-exports.getSecretsForPhase = function() {
+exports.getSecretsForPhase = function () {
     return Promise.resolve({});
 }
 
@@ -125,7 +84,7 @@ exports.getSecretsForPhase = function() {
  *   params: <params>
  * }
  */
-exports.createPhase = function(phaseContext, accountConfig) {
+exports.createPhase = function (phaseContext, accountConfig) {
     return createBuildPhaseCodeBuildProject(phaseContext)
         .then(codeBuildProject => {
             return getCodePipelinePhaseSpec(phaseContext);

--- a/lib/phases/handel/deploy-phase-service-policy.json
+++ b/lib/phases/handel/deploy-phase-service-policy.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "*"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/lib/phases/handel/index.js
+++ b/lib/phases/handel/index.js
@@ -8,18 +8,7 @@ function createDeployPhaseServiceRole(accountId) {
     return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
         .then(role => {
             let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
-            let policyDocument = {
-                Version: "2012-10-17",
-                Statement: [
-                    {
-                        Action: [
-                            '*'
-                        ],
-                        Resource: "*",
-                        Effect: "Allow"
-                    }
-                ]
-            }
+            let policyDocument = util.loadJsonFile(`${__dirname}/deploy-phase-service-policy.json`);
             return iamCalls.createPolicyIfNotExists(roleName, policyArn, policyDocument);
         })
         .then(policy => {

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -2,6 +2,7 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 const archiver = require('archiver');
 const path = require('path');
+const handlebars = require('handlebars');
 
 /**
  * Takes the given directory path and zips it up and stores it
@@ -79,6 +80,15 @@ exports.loadYamlFile = function(filePath) {
     }
 }
 
+exports.loadJsonFile = function(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    }
+    catch(e) {
+        return null;
+    }
+}
+
 exports.loadFile = function(filePath) {
     try {
         return fs.readFileSync(filePath, 'utf8');
@@ -86,4 +96,24 @@ exports.loadFile = function(filePath) {
     catch(e) {
         return null;
     }
+}
+
+/**
+ * Given a handlebars template filename and a Javascript object of the variables
+ * to inject in that template, compiles and returns the template
+ * 
+ * @param {String} filename - The full path of the template file on disk to read 
+ * @param {Object} variables - A Javascript object containing the variables to be used by Handlebars for the template
+ * @returns {String} - The finished template with variables replaced
+ */
+exports.compileHandlebarsTemplate = function(filename, variables) {
+    //TODO - This doesn't handle errors yet
+    return new Promise((resolve, reject) => {
+        fs.readFile(filename, 'utf-8', function(error, source) {
+            //Register any helpers we need
+            let template = handlebars.compile(source);
+            let output = template(variables);
+            resolve(output);
+        });
+    });
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "archiver": "^1.3.0",
     "async": "^2.4.0",
     "aws-sdk": "^2.9.0",
+    "handlebars": "^4.0.8",
     "inquirer": "^3.0.6",
     "js-yaml": "3.7.0",
     "winston": "^2.3.1"

--- a/test/aws/iam-calls-test.js
+++ b/test/aws/iam-calls-test.js
@@ -12,6 +12,7 @@ describe('iam calls', function() {
 
     afterEach(function() {
         sandbox.restore();
+        AWS.restore('IAM');
     });
 
     describe('createRole', function() {
@@ -37,7 +38,6 @@ describe('iam calls', function() {
             return iamCalls.getRole("FakeRole")
                 .then(role => {
                     expect(role).to.deep.equal({});
-                    AWS.restore('IAM');
                 });
         });
 
@@ -49,7 +49,6 @@ describe('iam calls', function() {
             return iamCalls.getRole("FakeRole")
                 .then(role => {
                     expect(role).to.be.null;
-                    AWS.restore('IAM');
                 });
         });
 
@@ -65,7 +64,6 @@ describe('iam calls', function() {
                 })
                 .catch(err => {
                     expect(err.code).to.equal(errorCode);
-                    AWS.restore('IAM');
                 })
         });
     });
@@ -98,7 +96,6 @@ describe('iam calls', function() {
             return iamCalls.attachPolicyToRole('FakeArn', 'FakeRole')
                 .then(response => {
                     expect(response).to.deep.equal({});
-                    AWS.restore('IAM');
                 });
         });
     });
@@ -112,7 +109,6 @@ describe('iam calls', function() {
             return iamCalls.getPolicy("FakeArn")
                 .then(policy => {
                     expect(policy).to.deep.equal({});
-                    AWS.restore('IAM');
                 });
         });
 
@@ -124,7 +120,6 @@ describe('iam calls', function() {
             return iamCalls.getPolicy("FakeArn")
                 .then(policy => {
                     expect(policy).to.be.null;
-                    AWS.restore('IAM');
                 });
         });
     });
@@ -138,7 +133,6 @@ describe('iam calls', function() {
             return iamCalls.createPolicy("PolicyName", {})
                 .then(policy => {
                     expect(policy).to.deep.equal({});
-                    AWS.restore('IAM');
                 });
         });
     });


### PR DESCRIPTION
This change grants the build phase of a pipeline access to the
parameters in EC2 Parameter Store under the app's namespace. If
the Handel app name is 'myapp', then it will have access to any
parameter of the format 'myapp*'.

This change also fixes the bug where codebuild and codepipeline
creations would fail because newly created roles werent available
yet.

Resolves #20 
Resolves #7 